### PR TITLE
NumberArrayFactory: Set "#step" to "any" if no precision is specified

### DIFF
--- a/src/Form/Control/NumberArrayFactory.php
+++ b/src/Form/Control/NumberArrayFactory.php
@@ -68,6 +68,9 @@ final class NumberArrayFactory implements ConcreteFormArrayFactoryInterface {
     if (NULL !== $definition->getPrecision()) {
       $form['#step'] = 1 / (10 ** $definition->getPrecision());
     }
+    else {
+      $form['#step'] = 'any';
+    }
 
     return $form;
   }


### PR DESCRIPTION
The default is 1 and #step is used for validation.