### PR TITLE
Use "blur" event instead of "change" for "date" fields

### DIFF
--- a/src/Form/Control/DateArrayFactory.php
+++ b/src/Form/Control/DateArrayFactory.php
@@ -44,9 +44,19 @@ final class DateArrayFactory extends AbstractConcreteFormArrayFactory {
   ): array {
     Assertion::isInstanceOf($definition, ControlDefinition::class);
     /** @var \Drupal\json_forms\JsonForms\Definition\Control\ControlDefinition $definition */
-    return [
+    $form = [
       '#type' => 'date',
     ] + BasicFormPropertiesFactory::createFieldProperties($definition, $formState);
+
+    // @phpstan-ignore-next-line
+    if ('change' === ($form['#ajax']['event'] ?? NULL)) {
+      // For input fields of type "date" the "change" event is triggered while
+      // entering a value, so we have to use "blur" instead.
+      // @phpstan-ignore-next-line
+      $form['#ajax']['event'] = 'blur';
+    }
+
+    return $form;
   }
 
   public function supportsDefinition(DefinitionInterface $definition): bool {

--- a/src/Form/Control/DatetimeArrayFactory.php
+++ b/src/Form/Control/DatetimeArrayFactory.php
@@ -44,9 +44,19 @@ final class DatetimeArrayFactory extends AbstractConcreteFormArrayFactory {
   ): array {
     Assertion::isInstanceOf($definition, ControlDefinition::class);
     /** @var \Drupal\json_forms\JsonForms\Definition\Control\ControlDefinition $definition */
-    return [
+    $form = [
       '#type' => 'datetime',
     ] + BasicFormPropertiesFactory::createFieldProperties($definition, $formState);
+
+    // @phpstan-ignore-next-line
+    if ('change' === ($form['#ajax']['event'] ?? NULL)) {
+      // For input fields of type "date" the "change" event is triggered while
+      // entering a value, so we have to use "blur" instead.
+      // @phpstan-ignore-next-line
+      $form['#ajax']['event'] = 'blur';
+    }
+
+    return $form;
   }
 
   public function supportsDefinition(DefinitionInterface $definition): bool {


### PR DESCRIPTION
For input fields of type "date" the "change" event is triggered while entering a value, so we have to use "blur" instead.

systopia-reference: 21580