### PR TITLE
Allow dots and spaces in property names

### DIFF
--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -15,33 +15,28 @@
   <config name="ignore_warnings_on_exit" value="true"/>
 
   <rule ref="vendor/drupal/coder/coder_sniffer/Drupal">
-    <!-- Conflicts with PHPStan type hints -->
-    <exclude name="Drupal.Commenting.FunctionComment.InvalidReturn"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ParamTypeSpaces"/>
-    <exclude name="Drupal.Commenting.FunctionComment.ReturnTypeSpaces"/>
-    <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
+    <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
+    <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
+    <exclude name="Drupal.Commenting.FunctionComment.ParamMissingDefinition"/>
+    <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
+
+    <!-- Don't enforce comments -->
+    <exclude name="Drupal.Commenting.VariableComment.Missing"/>
+    <exclude name="Drupal.Commenting.ClassComment.Missing"/>
+    <exclude name="Drupal.Commenting.FunctionComment.Missing"/>
+    <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
+
+    <!-- Dont enforce a single line seperated by a blank line -->
+    <exclude name="Drupal.Commenting.DocComment.ShortSingleLine"/>
+
     <!-- Allow "/** @phpstan-var ... */" -->
     <exclude name="Drupal.Commenting.InlineComment.DocBlock"/>
 
-    <!-- Don't enforce phpdoc type hint because it (might) only duplicate a PHP type hint -->
-    <exclude name="Drupal.Commenting.FunctionComment.ParamMissingDefinition"/>
-    <exclude name="Drupal.Commenting.VariableComment.MissingVar"/>
+    <!-- Allow intersection in @var -->
+    <exclude name="Drupal.Commenting.VariableComment.IncorrectVarType"/>
 
     <!-- False positive with license header -->
     <exclude name="Drupal.Commenting.FileComment.NamespaceNoFileDoc"/>
-
-    <!-- False positive when license header is set and variable has no comment -->
-    <!--<exclude name="Drupal.Commenting.VariableComment.WrongStyle"/>-->
-
-    <!-- Do not use object as type hint for \stdClass -->
-    <exclude name="Drupal.Commenting.FunctionComment.IncorrectParamVarName"/>
-
-    <exclude name="Drupal.Commenting.FunctionComment.Missing"/>
-    <exclude name="Drupal.Commenting.DocComment.MissingShort"/>
-    <exclude name="Drupal.Commenting.FunctionComment.MissingParamComment"/>
-    <exclude name="Drupal.Commenting.FunctionComment.MissingReturnComment"/>
-    <exclude name="Drupal.Commenting.ClassComment.Missing"/>
-    <exclude name="Drupal.Commenting.VariableComment.Missing"/>
   </rule>
 
   <rule ref="vendor/drupal/coder/coder_sniffer/DrupalPractice"/>

--- a/src/Form/Control/ArrayArrayFactory.php
+++ b/src/Form/Control/ArrayArrayFactory.php
@@ -71,14 +71,18 @@ final class ArrayArrayFactory extends AbstractConcreteFormArrayFactory {
       Assertion::integer($numItems);
     }
 
-    $callbackParentsPrefix = array_merge([AbstractJsonFormsForm::INTERNAL_VALUES_KEY], $definition->getPropertyPath());
+    $callbackParentsPrefix = array_merge(
+      [AbstractJsonFormsForm::INTERNAL_VALUES_KEY],
+      // @phpstan-ignore-next-line
+      $form['#parents'],
+    );
 
     if (0 === $numItems) {
       // Ensure we get an empty array if there's no item.
       $form[] = [
         '#type' => 'hidden',
         '#value' => [],
-        '#parents' => $definition->getPropertyPath(),
+        '#parents' => $definition->getPropertyFormParents(),
       ];
     }
     else {
@@ -106,7 +110,7 @@ final class ArrayArrayFactory extends AbstractConcreteFormArrayFactory {
             ],
             '#parents' => array_merge($callbackParentsPrefix, [$i, 'remove']),
             '#tree' => TRUE,
-            '#_controlPropertyPath' => $definition->getPropertyPath(),
+            '#_controlPropertyPath' => $definition->getPropertyFormParents(),
           ];
         }
       }

--- a/src/Form/Control/Callbacks/RecalculateCallback.php
+++ b/src/Form/Control/Callbacks/RecalculateCallback.php
@@ -24,6 +24,7 @@ use Assert\Assertion;
 use Drupal\Core\Ajax\AjaxResponse;
 use Drupal\Core\Ajax\InvokeCommand;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\json_forms\Form\Util\FieldNameUtil;
 
 final class RecalculateCallback {
 
@@ -33,7 +34,7 @@ final class RecalculateCallback {
   public static function onChange(array &$form, FormStateInterface $formState): AjaxResponse {
     /** @var \Drupal\json_forms\Form\AbstractJsonFormsForm $formObject */
     $formObject = $formState->getFormObject();
-    $data = $formObject->calculateData($formState);
+    $data = FieldNameUtil::toFormData($formObject->calculateData($formState));
 
     $response = new AjaxResponse();
     static::addInvokeCommands($response, $formState, $data);

--- a/src/Form/Control/Util/BasicFormPropertiesFactory.php
+++ b/src/Form/Control/Util/BasicFormPropertiesFactory.php
@@ -37,7 +37,7 @@ final class BasicFormPropertiesFactory {
    */
   public static function createBasicProperties(ControlDefinition $definition): array {
     $form = [
-      '#parents' => $definition->getPropertyPath(),
+      '#parents' => $definition->getPropertyFormParents(),
       '#title' => $definition->getLabel(),
       '#tree' => TRUE,
       '#_scope' => $definition->getFullScope(),

--- a/src/Form/Util/FieldNameUtil.php
+++ b/src/Form/Util/FieldNameUtil.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Drupal\json_forms\Form\Util;
+
+/**
+ * In PHP dots and spaces in form field names are converted to underscores. This
+ * class provides methods to allow transformation between form field names and
+ * JSON property names.
+ *
+ * @see https://www.php.net/manual/en/language.variables.external.php
+ */
+final class FieldNameUtil {
+
+  private const REPLACEMENTS = [
+    '.' => ':-:',
+    ' ' => ':_:',
+  ];
+
+  /**
+   * @phpstan-param array<int|string, mixed> $data JSON serializable.
+   *
+   * @phpstan-return array<int|string, mixed> JSON serializable.
+   */
+  public static function toFormData(array $data): array {
+    $newData = [];
+    foreach ($data as $key => $value) {
+      if (is_string($key)) {
+        $newKey = FieldNameUtil::toFormName($key);
+      }
+      else {
+        $newKey = $key;
+      }
+
+      $newData[$newKey] = is_array($value) ? self::toFormData($value) : $value;
+    }
+
+    return $newData;
+  }
+
+  public static function toFormName(string $name): string {
+    return str_replace(
+      array_keys(self::REPLACEMENTS),
+      array_values(self::REPLACEMENTS),
+      $name
+    );
+  }
+
+  /**
+   * @phpstan-param array<int|string> $path JSON path.
+   *
+   * @phpstan-return array<int|string>
+   *   Value to be used as #parents in form array.
+   */
+  public static function toFormParents(array $path): array {
+    foreach ($path as &$pathElement) {
+      if (is_string($pathElement)) {
+        $pathElement = FieldNameUtil::toFormName($pathElement);
+      }
+    }
+
+    return $path;
+  }
+
+  /**
+   * @phpstan-param array<int|string, mixed> $data JSON serializable.
+   *
+   * @phpstan-return array<int|string, mixed> JSON serializable.
+   */
+  public static function toJsonData(array $data): array {
+    $newData = [];
+    foreach ($data as $key => $value) {
+      if (is_string($key)) {
+        $newKey = FieldNameUtil::toJsonName($key);
+      }
+      else {
+        $newKey = $key;
+      }
+
+      $newData[$newKey] = is_array($value) ? self::toJsonData($value) : $value;
+    }
+
+    return $newData;
+  }
+
+  public static function toJsonName(string $name): string {
+    return str_replace(
+      array_values(self::REPLACEMENTS),
+      array_keys(self::REPLACEMENTS),
+      $name
+    );
+  }
+
+}

--- a/src/Form/Util/JsonConverter.php
+++ b/src/Form/Util/JsonConverter.php
@@ -25,7 +25,7 @@ use Assert\Assertion;
 final class JsonConverter {
 
   /**
-   * @return array<string, mixed>
+   * @return array<int|string, mixed>
    *
    * @throws \JsonException
    */
@@ -37,7 +37,7 @@ final class JsonConverter {
   }
 
   /**
-   * @param array<string, mixed> $data
+   * @param array<int|string, mixed> $data
    *
    * @throws \JsonException
    */

--- a/src/Form/Validation/FormValidationMapper.php
+++ b/src/Form/Validation/FormValidationMapper.php
@@ -23,22 +23,25 @@ namespace Drupal\json_forms\Form\Validation;
 
 use Assert\Assertion;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\json_forms\Form\Util\FieldNameUtil;
 use Drupal\json_forms\Form\Util\FormValueAccessor;
 use Opis\JsonSchema\JsonPointer;
 
 final class FormValidationMapper implements FormValidationMapperInterface {
 
   public function mapData(ValidationResult $validationResult, FormStateInterface $formState): void {
-    $formState->setValues($validationResult->getData());
+    $data = FieldNameUtil::toFormData($validationResult->getData());
+    $formState->setValues($data);
     $form = &$formState->getCompleteForm();
-    FormValueAccessor::setValue($form, [], $validationResult->getData());
+    FormValueAccessor::setValue($form, [], $data);
   }
 
   public function mapErrors(ValidationResult $validationResult, FormStateInterface $formState): void {
     foreach ($validationResult->getLeafErrorMessages() as $pointer => $messages) {
       $pointer = JsonPointer::parse($pointer);
       Assertion::notNull($pointer);
-      $element = ['#parents' => $pointer->absolutePath()];
+      // @phpstan-ignore-next-line
+      $element = ['#parents' => FieldNameUtil::toFormParents($pointer->absolutePath())];
       $formState->setError($element, implode("\n", $messages));
     }
   }

--- a/src/Form/Validation/FormValidator.php
+++ b/src/Form/Validation/FormValidator.php
@@ -20,8 +20,6 @@ declare(strict_types = 1);
 
 namespace Drupal\json_forms\Form\Validation;
 
-use Assert\Assertion;
-use Drupal\Core\Form\FormStateInterface;
 use Drupal\json_forms\Form\Util\JsonConverter;
 use Opis\JsonSchema\Validator as OpisValidator;
 use Systopia\JsonSchema\Errors\ErrorCollector;
@@ -37,10 +35,8 @@ final class FormValidator implements FormValidatorInterface {
   /**
    * @throws \JsonException
    */
-  public function validate(FormStateInterface $formState): ValidationResult {
-    $data = JsonConverter::toStdClass($formState->getValues());
-    $jsonSchema = $formState->get('jsonSchema');
-    Assertion::isInstanceOf($jsonSchema, \stdClass::class);
+  public function validate(\stdClass $jsonSchema, array $data): ValidationResult {
+    $data = JsonConverter::toStdClass($data);
     $errorCollector = new ErrorCollector();
     $this->validator->validate($data, $jsonSchema, ['errorCollector' => $errorCollector]);
 

--- a/src/Form/Validation/FormValidatorInterface.php
+++ b/src/Form/Validation/FormValidatorInterface.php
@@ -20,10 +20,11 @@ declare(strict_types = 1);
 
 namespace Drupal\json_forms\Form\Validation;
 
-use Drupal\Core\Form\FormStateInterface;
-
 interface FormValidatorInterface {
 
-  public function validate(FormStateInterface $formState): ValidationResult;
+  /**
+   * @phpstan-param array<int|string, mixed> $data JSON serializable.
+   */
+  public function validate(\stdClass $jsonSchema, array $data): ValidationResult;
 
 }

--- a/src/JsonForms/Definition/Control/ControlDefinition.php
+++ b/src/JsonForms/Definition/Control/ControlDefinition.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Drupal\json_forms\JsonForms\Definition\Control;
 
 use Assert\Assertion;
+use Drupal\json_forms\Form\Util\FieldNameUtil;
 use Drupal\json_forms\JsonForms\Definition\DefinitionInterface;
 use Drupal\json_forms\JsonForms\ScopePointer;
 
@@ -238,6 +239,13 @@ class ControlDefinition implements DefinitionInterface {
     }
 
     return $this->propertyFormName;
+  }
+
+  /**
+   * @return array<int|string> Value to be used as #parents in the form array.
+   */
+  public function getPropertyFormParents(): array {
+    return FieldNameUtil::toFormParents($this->getPropertyPath());
   }
 
   /**

--- a/tests/src/Form/Util/FieldNameUtilTest.php
+++ b/tests/src/Form/Util/FieldNameUtilTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types = 1);
+
+namespace Drupal\Tests\json_forms\Form\Util;
+
+use Drupal\json_forms\Form\Util\FieldNameUtil;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Drupal\json_forms\Form\Util\FieldNameUtil
+ */
+final class FieldNameUtilTest extends TestCase {
+
+  public function testToFormData(): void {
+    $data = ['foo.bar' => ['foo bar' => 'baz']];
+    $expected = ['foo:-:bar' => ['foo:_:bar' => 'baz']];
+    static::assertSame($expected, FieldNameUtil::toFormData($data));
+  }
+
+  public function testToFormName(): void {
+    static::assertSame('foo:-:bar', FieldNameUtil::toFormName('foo.bar'));
+    static::assertSame('foo:_:bar', FieldNameUtil::toFormName('foo bar'));
+    static::assertSame('foo:-:bar:_:baz', FieldNameUtil::toFormName('foo.bar baz'));
+  }
+
+  public static function testToFormParents(): void {
+    $path = ['foo.bar', 2, 'bar baz', 3];
+    $expected = ['foo:-:bar', 2, 'bar:_:baz', 3];
+    static::assertSame($expected, FieldNameUtil::toFormParents($path));
+  }
+
+  public function testToJsonSchemaData(): void {
+    $data = ['foo:-:bar' => ['foo:_:bar' => 'baz']];
+    $expected = ['foo.bar' => ['foo bar' => 'baz']];
+    static::assertSame($expected, FieldNameUtil::toJsonData($data));
+  }
+
+  public function testToJsonSchemaName(): void {
+    static::assertSame('foo.bar', FieldNameUtil::toJsonName('foo:-:bar'));
+    static::assertSame('foo bar', FieldNameUtil::toJsonName('foo:_:bar'));
+    static::assertSame('foo.bar baz', FieldNameUtil::toJsonName('foo:-:bar:_:baz'));
+  }
+
+}


### PR DESCRIPTION
PHP converts dots and spaces in form field names to underscores.