### PR TITLE
ControlDefinition: Handle multiple types in property schema

### DIFF
--- a/src/JsonForms/Definition/Control/ControlDefinition.php
+++ b/src/JsonForms/Definition/Control/ControlDefinition.php
@@ -282,7 +282,22 @@ class ControlDefinition implements DefinitionInterface {
     return $this->controlSchema->suffix ?? NULL;
   }
 
+  /**
+   * If multiple types are set in the property schema, the first non "null"
+   * value is returned, or "null" there's no such value. If a single type is
+   * set, it is returned as is.
+   */
   public function getType(): string {
+    if (is_array($this->propertySchema->type)) {
+      foreach ($this->propertySchema->type as $type) {
+        if ('null' !== $type) {
+          return $type;
+        }
+
+        return 'null';
+      }
+    }
+
     return $this->propertySchema->type;
   }
 


### PR DESCRIPTION
There might be more than one type allowed for a property. The first non "null" is treated as relevant for the form generation.