### PR TITLE
Add support for control rules

### DIFF
--- a/json_forms.services.yml
+++ b/json_forms.services.yml
@@ -15,3 +15,6 @@ services:
   Drupal\json_forms\Form\Validation\FormValidatorInterface:
     class: Drupal\json_forms\Form\Validation\FormValidator
     arguments: ['@Opis\JsonSchema\Validator']
+
+  Drupal\json_forms\Form\Control\Rule\StatesArrayFactoryInterface:
+    class: Drupal\json_forms\Form\Control\Rule\StatesArrayFactory

--- a/src/Form/Control/Rule/StatesArrayFactory.php
+++ b/src/Form/Control/Rule/StatesArrayFactory.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\json_forms\Form\Control\Rule;
+
+use Drupal\json_forms\Form\Control\Util\FormPropertyUtil;
+use Drupal\json_forms\JsonForms\ScopePointer;
+
+final class StatesArrayFactory implements StatesArrayFactoryInterface {
+
+  private StatesBuilder $statesBuilder;
+
+  public function __construct() {
+    $this->statesBuilder = new StatesBuilder();
+  }
+
+  /**
+   * @phpstan-return array<string, mixed>
+   */
+  public function createStatesArray(\stdClass $rule): array {
+    $this->statesBuilder->clear();
+    $this->addStates(
+      $rule->effect,
+      $this->getFieldName($rule->condition->scope),
+      $rule->condition->schema,
+    );
+
+    return $this->statesBuilder->toArray();
+  }
+
+  private function getFieldName(string $scope): string {
+    return FormPropertyUtil::getFormNameForPropertyPath(ScopePointer::new($scope)->getPropertyPath());
+  }
+
+  private function addStates(string $effect, string $fieldName, \stdClass $schema, bool $negate = FALSE): void {
+    if (property_exists($schema, 'not')) {
+      $this->addStates($effect, $fieldName, $schema->not, !$negate);
+    }
+
+    if (property_exists($schema, 'const')) {
+      $this->statesBuilder->add($effect, $fieldName, $schema->const, $negate);
+    }
+
+    if (property_exists($schema, 'enum')) {
+      $this->statesBuilder->add($effect, $fieldName, $schema->enum, $negate);
+    }
+
+    if (property_exists($schema, 'properties')) {
+      foreach ($schema->properties as $property => $propertySchema) {
+        $propertyFieldName = $fieldName . '[' . $property . ']';
+        $this->addStates($effect, $propertyFieldName, $propertySchema, $negate);
+      }
+    }
+  }
+
+}

--- a/src/Form/Control/Rule/StatesArrayFactoryInterface.php
+++ b/src/Form/Control/Rule/StatesArrayFactoryInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\json_forms\Form\Control\Rule;
+
+interface StatesArrayFactoryInterface {
+
+  /**
+   * @phpstan-return array<string, mixed>
+   */
+  public function createStatesArray(\stdClass $rule): array;
+
+}

--- a/src/Form/Control/Rule/StatesBuilder.php
+++ b/src/Form/Control/Rule/StatesBuilder.php
@@ -1,0 +1,124 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\json_forms\Form\Control\Rule;
+
+/**
+ * @phpstan-type statesT array<string, array<string, array<array<string, mixed>|'and'|'or'|'xor'>>>
+ * @phpstan-type conditionT array{checked: bool}|array{empty: bool}|array{value: scalar}
+ */
+final class StatesBuilder {
+
+  /**
+   * @phpstan-var statesT
+   */
+  private array $states = [];
+
+  /**
+   * @phpstan-param scalar|array<scalar> $value
+   */
+  public function add(
+    string $effect,
+    string $fieldName,
+    $value,
+    bool $negate
+  ): self {
+    foreach ($this->getStates($effect, $negate) as $state) {
+      $selector = '[name="' . $fieldName . '"]';
+      if (isset($this->states[$state][$selector])) {
+        $this->states[$state][$selector][] = 'and';
+      }
+
+      $this->states[$state][$selector][] = $this->buildCondition($value);
+    }
+
+    return $this;
+  }
+
+  public function clear(): void {
+    $this->states = [];
+  }
+
+  /**
+   * @phpstan-return array<string>
+   *
+   * phpcs:disable Generic.Metrics.CyclomaticComplexity.TooHigh
+   */
+  private function getStates(string $effect, bool $negate): array {
+  // phpcs:enable
+    switch ($effect) {
+      case 'HIDE':
+        return $negate ? ['visible'] : ['invisible'];
+
+      case 'SHOW':
+        return $negate ? ['invisible'] : ['visible'];
+
+      case 'ENABLE':
+        return $negate ? ['disabled'] : ['enabled'];
+
+      case 'DISABLE':
+        return $negate ? ['enabled'] : ['disabled'];
+
+      default:
+        return [];
+    }
+  }
+
+  /**
+   * @phpstan-param scalar|array<scalar>|null $value
+   *
+   * @phpstan-return conditionT|array<conditionT|'or'>
+   */
+  private function buildCondition($value): array {
+    if (is_bool($value)) {
+      return ['checked' => $value];
+    }
+
+    if (NULL === $value) {
+      return ['empty' => TRUE];
+    }
+
+    if (!is_array($value)) {
+      return ['value' => $value];
+    }
+
+    $condition = [];
+    foreach ($value as $v) {
+      if (!is_array($v)) {
+        /** @phpstan-var conditionT $subCondition */
+        $subCondition = $this->buildCondition($v);
+        $condition[] = $subCondition;
+        $condition[] = 'or';
+      }
+    }
+    array_pop($condition);
+
+    return $condition;
+  }
+
+  /**
+   * @phpstan-return statesT
+   */
+  public function toArray(): array {
+    return $this->states;
+  }
+
+}

--- a/src/Form/Control/Util/BasicFormPropertiesFactory.php
+++ b/src/Form/Control/Util/BasicFormPropertiesFactory.php
@@ -23,6 +23,7 @@ namespace Drupal\json_forms\Form\Control\Util;
 
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\json_forms\Form\Control\Callbacks\RecalculateCallback;
+use Drupal\json_forms\Form\Control\Rule\StatesArrayFactory;
 use Drupal\json_forms\JsonForms\Definition\Control\ControlDefinition;
 
 final class BasicFormPropertiesFactory {
@@ -93,6 +94,11 @@ final class BasicFormPropertiesFactory {
         'progress' => [],
         'disable-refocus' => TRUE,
       ];
+    }
+
+    if (NULL !== $definition->getRule()) {
+      $statesArrayFactory = new StatesArrayFactory();
+      $form['#states'] = $statesArrayFactory->createStatesArray($definition->getRule());
     }
 
     return array_merge(static::createBasicProperties($definition), $form);

--- a/src/Form/Control/Util/FormPropertyUtil.php
+++ b/src/Form/Control/Util/FormPropertyUtil.php
@@ -27,7 +27,7 @@ final class FormPropertyUtil {
    * @phpstan-param array<int|string> $propertyPath
    */
   public static function getFormNameForPropertyPath(array $propertyPath): string {
-    $formName = (string) \reset($propertyPath);
+    $formName = (string) reset($propertyPath);
     while (FALSE !== ($next = next($propertyPath))) {
       $formName .= '[' . $next . ']';
     }

--- a/src/Form/Control/Util/FormPropertyUtil.php
+++ b/src/Form/Control/Util/FormPropertyUtil.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (C) 2022 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\json_forms\Form\Control\Util;
+
+final class FormPropertyUtil {
+
+  /**
+   * @phpstan-param array<int|string> $propertyPath
+   */
+  public static function getFormNameForPropertyPath(array $propertyPath): string {
+    $formName = (string) \reset($propertyPath);
+    while (FALSE !== ($next = next($propertyPath))) {
+      $formName .= '[' . $next . ']';
+    }
+
+    return $formName;
+  }
+
+}

--- a/src/Form/Markup/HtmlMarkupArrayFactory.php
+++ b/src/Form/Markup/HtmlMarkupArrayFactory.php
@@ -47,17 +47,17 @@ final class HtmlMarkupArrayFactory extends AbstractConcreteFormArrayFactory {
     Assertion::isInstanceOf($definition, MarkupDefinition::class);
     /** @var \Drupal\json_forms\JsonForms\Definition\Markup\MarkupDefinition $definition */
 
-    $form = [
+    $element = [
       '#type' => 'item',
       '#title' => $definition->getLabel(),
       '#markup' => $definition->getContent(),
     ];
 
     if (NULL !== $definition->getRule()) {
-      $form['#states'] = $this->statesArrayFactory->createStatesArray($definition->getRule());
+      $element['#states'] = $this->statesArrayFactory->createStatesArray($definition->getRule());
     }
 
-    return $form;
+    return $element;
   }
 
   public function supportsDefinition(DefinitionInterface $definition): bool {

--- a/src/Form/Markup/HtmlMarkupArrayFactory.php
+++ b/src/Form/Markup/HtmlMarkupArrayFactory.php
@@ -24,11 +24,18 @@ namespace Drupal\json_forms\Form\Markup;
 use Assert\Assertion;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\json_forms\Form\AbstractConcreteFormArrayFactory;
+use Drupal\json_forms\Form\Control\Rule\StatesArrayFactoryInterface;
 use Drupal\json_forms\Form\FormArrayFactoryInterface;
 use Drupal\json_forms\JsonForms\Definition\DefinitionInterface;
 use Drupal\json_forms\JsonForms\Definition\Markup\MarkupDefinition;
 
 final class HtmlMarkupArrayFactory extends AbstractConcreteFormArrayFactory {
+
+  private StatesArrayFactoryInterface $statesArrayFactory;
+
+  public function __construct(StatesArrayFactoryInterface $statesArrayFactory) {
+    $this->statesArrayFactory = $statesArrayFactory;
+  }
 
   /**
    * {@inheritDoc}
@@ -40,11 +47,17 @@ final class HtmlMarkupArrayFactory extends AbstractConcreteFormArrayFactory {
     Assertion::isInstanceOf($definition, MarkupDefinition::class);
     /** @var \Drupal\json_forms\JsonForms\Definition\Markup\MarkupDefinition $definition */
 
-    return [
+    $form = [
       '#type' => 'item',
       '#title' => $definition->getLabel(),
       '#markup' => $definition->getContent(),
     ];
+
+    if (NULL !== $definition->getRule()) {
+      $form['#states'] = $this->statesArrayFactory->createStatesArray($definition->getRule());
+    }
+
+    return $form;
   }
 
   public function supportsDefinition(DefinitionInterface $definition): bool {

--- a/src/JsonForms/Definition/Control/ControlDefinition.php
+++ b/src/JsonForms/Definition/Control/ControlDefinition.php
@@ -22,6 +22,7 @@ declare(strict_types=1);
 namespace Drupal\json_forms\JsonForms\Definition\Control;
 
 use Assert\Assertion;
+use Drupal\json_forms\Form\Control\Util\FormPropertyUtil;
 use Drupal\json_forms\Form\Util\FieldNameUtil;
 use Drupal\json_forms\JsonForms\Definition\DefinitionInterface;
 use Drupal\json_forms\JsonForms\ScopePointer;
@@ -230,12 +231,7 @@ class ControlDefinition implements DefinitionInterface {
    */
   public function getPropertyFormName(): string {
     if (NULL == $this->propertyFormName) {
-      $path = $this->getPropertyPath();
-      $formName = (string) \reset($path);
-      while (FALSE !== ($next = next($path))) {
-        $formName .= '[' . $next . ']';
-      }
-      $this->propertyFormName = $formName;
+      $this->propertyFormName = FormPropertyUtil::getFormNameForPropertyPath($this->getPropertyPath());
     }
 
     return $this->propertyFormName;
@@ -257,6 +253,10 @@ class ControlDefinition implements DefinitionInterface {
 
   public function getPropertySchema(): \stdClass {
     return $this->propertySchema;
+  }
+
+  public function getRule(): ?\stdClass {
+    return $this->controlSchema->rule ?? NULL;
   }
 
   public function getFullScope(): string {

--- a/src/JsonForms/Definition/Markup/MarkupDefinition.php
+++ b/src/JsonForms/Definition/Markup/MarkupDefinition.php
@@ -67,6 +67,10 @@ final class MarkupDefinition implements DefinitionInterface {
     return $this->markupSchema;
   }
 
+  public function getRule(): ?\stdClass {
+    return $this->markupSchema->rule ?? NULL;
+  }
+
   public function getType(): string {
     return $this->markupSchema->type;
   }

--- a/tests/src/Unit/Form/Rule/StatesArrayFactoryTest.php
+++ b/tests/src/Unit/Form/Rule/StatesArrayFactoryTest.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\Tests\json_forms\Unit\Form\Rule;
+
+use Drupal\json_forms\Form\Control\Rule\StatesArrayFactory;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @covers \Drupal\json_forms\Form\Control\Rule\StatesArrayFactory
+ * @covers \Drupal\json_forms\Form\Control\Rule\StatesBuilder
+ */
+final class StatesArrayFactoryTest extends TestCase {
+
+  private StatesArrayFactory $factory;
+
+  protected function setUp(): void {
+    parent::setUp();
+    $this->factory = new StatesArrayFactory();
+  }
+
+  public function testHide(): void {
+    $rule = (object) [
+      'effect' => 'HIDE',
+      'condition' => (object) [
+        'scope' => '#/properties/foo/properties/bar',
+        'schema' => (object) ['const' => 'bar'],
+      ],
+    ];
+
+    static::assertSame(
+      [
+        'invisible' => [
+          '[name="foo[bar]"]' => [
+            ['value' => 'bar'],
+          ],
+        ],
+      ],
+      $this->factory->createStatesArray($rule)
+    );
+  }
+
+  public function testNotHide(): void {
+    $rule = (object) [
+      'effect' => 'HIDE',
+      'condition' => (object) [
+        'scope' => '#/properties/foo/properties/bar',
+        'schema' => (object) ['not' => (object) ['const' => 'bar']],
+      ],
+    ];
+
+    static::assertSame(
+      [
+        'visible' => [
+          '[name="foo[bar]"]' => [
+            ['value' => 'bar'],
+          ],
+        ],
+      ],
+      $this->factory->createStatesArray($rule)
+    );
+  }
+
+  public function testShowEnum(): void {
+    $rule = (object) [
+      'effect' => 'SHOW',
+      'condition' => (object) [
+        'scope' => '#/properties/foo/properties/bar',
+        'schema' => (object) ['enum' => ['foo', 'bar']],
+      ],
+    ];
+
+    static::assertSame(
+      [
+        'visible' => [
+          '[name="foo[bar]"]' => [
+            [
+              ['value' => 'foo'],
+              'or',
+              ['value' => 'bar'],
+            ],
+          ],
+        ],
+      ],
+      $this->factory->createStatesArray($rule)
+    );
+  }
+
+  public function testProperties(): void {
+    $rule = (object) [
+      'effect' => 'ENABLE',
+      'condition' => (object) [
+        'scope' => '#/properties/foo/properties/bar',
+        'schema' => (object) [
+          'properties' => (object) [
+            'baz' => (object) ['const' => FALSE],
+          ],
+        ],
+      ],
+    ];
+
+    static::assertSame(
+      [
+        'enabled' => [
+          '[name="foo[bar][baz]"]' => [
+            ['checked' => FALSE],
+          ],
+        ],
+      ],
+      $this->factory->createStatesArray($rule)
+    );
+  }
+
+}


### PR DESCRIPTION
This PR adds support for JSON Forms rules (https://jsonforms.io/docs/uischema/rules/) via Drupal Form `#states` (https://www.drupal.org/docs/drupal-apis/form-api/conditional-form-fields). This approach has some limitations:

* Scopes must reference a concrete form field, i.e. no object or arrays are possible.
* `schema` is limited to the keywords `const`, `enum`, `properties`, and `not`.