### PR TITLE
Ensure AJAX calls are finished before form submit

### DIFF
--- a/js/submit.js
+++ b/js/submit.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Ensure all AJAX call are finished before submit on button click. If this is
+ * omitted the focused field (if any) is missing in the submitted data in case
+ * the field was changed and performs an AJAX call on change.
+ */
+(function ($, Drupal, once) {
+  Drupal.behaviors.jsonFormsSubmit = {
+    attach: function (context) {
+      function submit(event) {
+        // If there's an active AJAX call wait for ajaxStop event.
+        if ($.active > 0) {
+          $(document).on('ajaxStop', () => event.target.click());
+          event.preventDefault();
+        }
+      }
+
+      function attachClick(context) {
+        once('json-forms-submit', 'input[type="submit"]', context).forEach((element) => {
+          element.onclick = submit;
+        });
+      }
+
+      attachClick(context);
+    }
+  };
+
+})(jQuery, Drupal, once);

--- a/js/submit.js
+++ b/js/submit.js
@@ -21,23 +21,31 @@
  * the field was changed and performs an AJAX call on change.
  */
 (function ($, Drupal, once) {
+
+  let ajaxCallRunning = false;
+  let submitButtonClicked;
+
+  $(document).on('ajaxStart', () => ajaxCallRunning = true);
+
+  $(document).on('ajaxStop', () => {
+    ajaxCallRunning = false;
+    if (submitButtonClicked) {
+      submitButtonClicked.click();
+    }
+  });
+
   Drupal.behaviors.jsonFormsSubmit = {
     attach: function (context) {
-      function submit(event) {
-        // If there's an active AJAX call wait for ajaxStop event.
-        if ($.active > 0) {
-          $(document).on('ajaxStop', () => event.target.click());
-          event.preventDefault();
-        }
-      }
-
-      function attachClick(context) {
-        once('json-forms-submit', 'input[type="submit"]', context).forEach((element) => {
-          element.onclick = submit;
+      once('json-forms-submit', '.json-forms-submit', context).forEach((element) => {
+        $(element).on('click', (event) => {
+          if (ajaxCallRunning) {
+            submitButtonClicked = event.target;
+            event.preventDefault();
+          } else {
+            submitButtonClicked = null;
+          }
         });
-      }
-
-      attachClick(context);
+      });
     }
   };
 

--- a/json_forms.libraries.yml
+++ b/json_forms.libraries.yml
@@ -8,3 +8,12 @@ confirm:
     - core/drupal.dialog
     - core/jquery
     - core/once
+
+submit:
+  version: 0.1.0
+  js:
+    js/submit.js: {}
+  dependencies:
+    - core/drupal
+    - core/jquery
+    - core/once

--- a/src/Form/AbstractJsonFormsForm.php
+++ b/src/Form/AbstractJsonFormsForm.php
@@ -100,9 +100,10 @@ abstract class AbstractJsonFormsForm extends FormBase {
     \stdClass $uiSchema,
     int $flags = 0
   ): array {
+    $recalculateOnChange = (bool) ($flags & self::FLAG_RECALCULATE_ONCHANGE);
     $formState->set('jsonSchema', $jsonSchema);
     $formState->set('uiSchema', $uiSchema);
-    $formState->set('recalculateOnChange', (bool) ($flags & self::FLAG_RECALCULATE_ONCHANGE));
+    $formState->set('recalculateOnChange', $recalculateOnChange);
 
     if (new \stdClass() == $uiSchema) {
       return [];
@@ -112,6 +113,11 @@ abstract class AbstractJsonFormsForm extends FormBase {
     $form = $this->formArrayFactory->createFormArray($definition, $formState);
     // @phpstan-ignore-next-line
     $form['#attributes']['class'][] = 'json-forms';
+
+    if ($recalculateOnChange) {
+      // @phpstan-ignore-next-line
+      $form['#attached']['library'][] = 'json_forms/submit';
+    }
 
     return $form;
   }

--- a/src/Form/Control/SubmitButtonArrayFactory.php
+++ b/src/Form/Control/SubmitButtonArrayFactory.php
@@ -62,6 +62,7 @@ final class SubmitButtonArrayFactory extends AbstractConcreteFormArrayFactory {
       // Override value set in BasicFormPropertiesFactory.
       '#limit_validation_errors' => NULL,
       '#_data' => $definition->getOptionsValue('data'),
+      '#attributes' => ['class' => ['json-forms-submit']],
     ] + BasicFormPropertiesFactory::createFieldProperties($definition, $formState);
 
     if (NULL !== $definition->getOptionsValue('confirm')) {


### PR DESCRIPTION
With this change it is ensured that all AJAX call are finished before submit on button click. If this is omitted the focused field (if any) is missing in the submitted data in case the field was changed and performs an AJAX call on change.

systopia-reference: 22884