### PR TITLE
Render arrays as tables by default

### DIFF
--- a/src/Form/Layout/AbstractLayoutArrayFactory.php
+++ b/src/Form/Layout/AbstractLayoutArrayFactory.php
@@ -34,7 +34,8 @@ abstract class AbstractLayoutArrayFactory extends AbstractConcreteFormArrayFacto
   /**
    * {@inheritDoc}
    */
-  public function createFormArray(DefinitionInterface $definition,
+  public function createFormArray(
+    DefinitionInterface $definition,
     FormStateInterface $formState,
     FormArrayFactoryInterface $formArrayFactory
   ): array {
@@ -56,7 +57,8 @@ abstract class AbstractLayoutArrayFactory extends AbstractConcreteFormArrayFacto
    *
    * @throws \InvalidArgumentException
    */
-  protected function createElementsFormArray(LayoutDefinition $definition,
+  protected function createElementsFormArray(
+    LayoutDefinition $definition,
     FormStateInterface $formState,
     FormArrayFactoryInterface $formArrayFactory
   ): array {
@@ -69,10 +71,24 @@ abstract class AbstractLayoutArrayFactory extends AbstractConcreteFormArrayFacto
         $key = $index;
       }
 
-      $form[$key] = $formArrayFactory->createFormArray($element, $formState);
+      $form[$key] = $this->createElementFormArray($element, $formState, $formArrayFactory);
     }
 
     return $form;
+  }
+
+  /**
+   * @return array<int|string, mixed>
+   *   A form array for the specified element.
+   *
+   * @throws \InvalidArgumentException
+   */
+  protected function createElementFormArray(
+    DefinitionInterface $element,
+    FormStateInterface $formState,
+    FormArrayFactoryInterface $formArrayFactory
+  ): array {
+    return $formArrayFactory->createFormArray($element, $formState);
   }
 
 }

--- a/src/Form/Layout/TableRowArrayFactory.php
+++ b/src/Form/Layout/TableRowArrayFactory.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * Copyright (C) 2023 SYSTOPIA GmbH
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+declare(strict_types=1);
+
+namespace Drupal\json_forms\Form\Layout;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\json_forms\Form\FormArrayFactoryInterface;
+use Drupal\json_forms\JsonForms\Definition\DefinitionInterface;
+use Drupal\json_forms\JsonForms\Definition\Layout\LayoutDefinition;
+
+/**
+ * Creates an array for a row in a table render element.
+ */
+final class TableRowArrayFactory extends AbstractLayoutArrayFactory {
+
+  public function supportsDefinition(DefinitionInterface $definition): bool {
+    return $definition instanceof LayoutDefinition && 'TableRow' === $definition->getType();
+  }
+
+  protected function createBasicFormArray(LayoutDefinition $definition): array {
+    return [];
+  }
+
+  protected function createElementFormArray(
+    DefinitionInterface $element,
+    FormStateInterface $formState,
+    FormArrayFactoryInterface $formArrayFactory
+  ): array {
+    return ['#title_display' => 'invisible']
+      + parent::createElementFormArray($element, $formState, $formArrayFactory);
+  }
+
+}


### PR DESCRIPTION
This saves a lot of space if an array item has many input fields.

Example:
Before
![before](https://github.com/systopia/drupal-json_forms/assets/5405481/d27257aa-63a4-4873-ac28-ad32d705c057)
After
![after](https://github.com/systopia/drupal-json_forms/assets/5405481/39815a5b-cf5e-4121-8692-b7e45724739c)

systopia-reference: 22947