### PR TITLE
HtmlMarkupArrayFactory: Display only markup only if no label is set

### DIFF
--- a/src/Form/Markup/HtmlMarkupArrayFactory.php
+++ b/src/Form/Markup/HtmlMarkupArrayFactory.php
@@ -48,13 +48,17 @@ final class HtmlMarkupArrayFactory extends AbstractConcreteFormArrayFactory {
     /** @var \Drupal\json_forms\JsonForms\Definition\Markup\MarkupDefinition $definition */
 
     $element = [
-      '#type' => 'item',
-      '#title' => $definition->getLabel(),
       '#markup' => $definition->getContent(),
     ];
 
-    if (NULL !== $definition->getRule()) {
-      $element['#states'] = $this->statesArrayFactory->createStatesArray($definition->getRule());
+    // Only use 'item' as type if necessary, otherwise just display the markup.
+    if (NULL !== $definition->getLabel() || NULL !== $definition->getRule()) {
+      $element['#type'] = 'item';
+      $element['#input'] = FALSE;
+      $element['#title'] = $definition->getLabel();
+      if (NULL !== $definition->getRule()) {
+        $element['#states'] = $this->statesArrayFactory->createStatesArray($definition->getRule());
+      }
     }
 
     return $element;


### PR DESCRIPTION
If neither label nor rules are set only the markup will be displayed, i.e. `#type` is not set to `item`.