### PR TITLE
Add option to hide labels

### DIFF
--- a/src/Form/Control/Util/BasicFormPropertiesFactory.php
+++ b/src/Form/Control/Util/BasicFormPropertiesFactory.php
@@ -52,6 +52,12 @@ final class BasicFormPropertiesFactory {
       $form['#attributes'] = ['placeholder' => $definition->getOptionsValue('placeholder')];
     }
 
+    // Custom option to hide labels, so they are not shown in the form by
+    // default, but can be used in validation errors.
+    if (TRUE === $definition->getOptionsValue('hideLabel')) {
+      $form['#title_display'] = 'invisible';
+    }
+
     return $form;
   }
 


### PR DESCRIPTION
This is a custom option to hide labels, so they are not shown in the form by default, but can be used in validation errors.

systopia-reference: 25642