### PR TITLE
Add support for the `$limitValidation` keyword

### DIFF
--- a/src/Form/FormArrayFactory.php
+++ b/src/Form/FormArrayFactory.php
@@ -40,6 +40,10 @@ final class FormArrayFactory implements FormArrayFactoryInterface {
   }
 
   public function createFormArray(DefinitionInterface $definition, FormStateInterface $formState): array {
+    if (NULL !== $definition->getKeywordValue('$limitValidation')) {
+      $formState->set('$limitValidationUsed', TRUE);
+    }
+
     foreach ($this->formArrayFactories as $factory) {
       if ($factory->supportsDefinition($definition)) {
         $form = $factory->createFormArray($definition, $formState, $this);


### PR DESCRIPTION
The `$limitValidation` keyword allows limited validation under specified conditions. See
https://github.com/systopia/opis-json-schema-ext?tab=readme-ov-file#limit-validation

systopia-reference: 28662