### PR TITLE
Fix: Add support for the `$limitValidation` keyword

### DIFF
--- a/src/Form/AbstractJsonFormsForm.php
+++ b/src/Form/AbstractJsonFormsForm.php
@@ -111,6 +111,10 @@ abstract class AbstractJsonFormsForm extends FormBase {
       return [];
     }
 
+    if (property_exists($jsonSchema, '$limitValidation')) {
+      $formState->set('$limitValidationUsed', TRUE);
+    }
+
     $definition = DefinitionFactory::createDefinition($uiSchema, $jsonSchema);
     $form = $this->formArrayFactory->createFormArray($definition, $formState);
 

--- a/src/Form/FormArrayFactory.php
+++ b/src/Form/FormArrayFactory.php
@@ -40,7 +40,9 @@ final class FormArrayFactory implements FormArrayFactoryInterface {
   }
 
   public function createFormArray(DefinitionInterface $definition, FormStateInterface $formState): array {
-    if (NULL !== $definition->getKeywordValue('$limitValidation')) {
+    if ($definition instanceof ControlDefinition
+      && NULL !== $definition->getObjectKeywordValue('$limitValidation')
+    ) {
       $formState->set('$limitValidationUsed', TRUE);
     }
 


### PR DESCRIPTION
The `$limitValidation` keyword allows limited validation under specified conditions. See
https://github.com/systopia/opis-json-schema-ext?tab=readme-ov-file#limit-validation