### PR TITLE
Allow to define CSS classes for any element

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,29 @@ be achieved with this CSS selector:
 ```css
 :not(.json-forms-description-tooltip)
 ```
+### Custom CSS Classes
+
+For any control and layout it is possible to specify CSS classes in the UI
+schema that will be added to the generated HTML code. The classes can be set at
+the property `cssClasses` in the `options` property, e.g.:
+
+```json
+{
+  "type": "VerticalLayout",
+  "elements": [
+    {
+      "type": "Control",
+      "scope": "#/properties/name",
+      "options": {
+        "cssClasses": ["my-name-control-class"]
+      }
+    }
+  ],
+  "options": {
+    "cssClasses": ["my-layout-class"]
+  }
+}
+```
 
 ## Limitations
 

--- a/src/Form/FormArrayFactory.php
+++ b/src/Form/FormArrayFactory.php
@@ -53,6 +53,13 @@ final class FormArrayFactory implements FormArrayFactoryInterface {
           $formState->set(['form', $definition->getPropertyFormName()], $form);
         }
 
+        // @phpstan-ignore offsetAccess.nonOffsetAccessible
+        $form['#attributes']['class'] =
+          // @phpstan-ignore binaryOp.invalid
+          ($definition->getOptionsValue('cssClasses') ?? []) +
+          // @phpstan-ignore offsetAccess.nonOffsetAccessible
+          ($form['#attributes']['class'] ?? []);
+
         return $form;
       }
     }

--- a/src/JsonForms/Definition/Control/ControlDefinition.php
+++ b/src/JsonForms/Definition/Control/ControlDefinition.php
@@ -216,13 +216,7 @@ class ControlDefinition implements DefinitionInterface {
     return $this->controlSchema->options ?? NULL;
   }
 
-  /**
-   * @param string $key
-   * @param mixed $default
-   *
-   * @return mixed
-   */
-  public function getOptionsValue(string $key, $default = NULL) {
+  public function getOptionsValue(string $key, mixed $default = NULL): mixed {
     return $this->controlSchema->options->{$key} ?? $default;
   }
 

--- a/src/JsonForms/Definition/Custom/CustomDefinition.php
+++ b/src/JsonForms/Definition/Custom/CustomDefinition.php
@@ -50,6 +50,15 @@ final class CustomDefinition implements DefinitionInterface {
     $this->rootDefinition = $rootDefinition ?? $this;
   }
 
+  public function getOptions(): ?\stdClass {
+    return $this->uiSchema->options ?? NULL;
+  }
+
+  public function getOptionsValue(string $key, mixed $default = NULL): mixed {
+    // @phpstan-ignore property.dynamicName
+    return $this->uiSchema->options->{$key} ?? $default;
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/JsonForms/Definition/Custom/MarkupDefinition.php
+++ b/src/JsonForms/Definition/Custom/MarkupDefinition.php
@@ -52,6 +52,15 @@ final class MarkupDefinition implements DefinitionInterface {
     return $this->markupSchema->contentMediaType;
   }
 
+  public function getOptions(): ?\stdClass {
+    return $this->markupSchema->options ?? NULL;
+  }
+
+  public function getOptionsValue(string $key, mixed $default = NULL): mixed {
+    // @phpstan-ignore property.dynamicName
+    return $this->markupSchema->options->{$key} ?? $default;
+  }
+
   /**
    * {@inheritDoc}
    */

--- a/src/JsonForms/Definition/DefinitionInterface.php
+++ b/src/JsonForms/Definition/DefinitionInterface.php
@@ -23,6 +23,10 @@ namespace Drupal\json_forms\JsonForms\Definition;
 
 interface DefinitionInterface {
 
+  public function getOptions(): ?\stdClass;
+
+  public function getOptionsValue(string $key, mixed $default = NULL): mixed;
+
   /**
    * @param mixed $default
    *

--- a/src/JsonForms/Definition/Layout/LayoutDefinition.php
+++ b/src/JsonForms/Definition/Layout/LayoutDefinition.php
@@ -94,13 +94,7 @@ class LayoutDefinition implements DefinitionInterface {
     return $this->layoutSchema->options ?? NULL;
   }
 
-  /**
-   * @param string $key
-   * @param mixed $default
-   *
-   * @return mixed
-   */
-  public function getOptionsValue(string $key, $default = NULL) {
+  public function getOptionsValue(string $key, mixed $default = NULL): mixed {
     return $this->layoutSchema->options->{$key} ?? $default;
   }
 


### PR DESCRIPTION
This makes it possible for any control and layout to specify CSS classes in the UI
schema that will be added to the generated HTML code. The classes can be set at
the property `cssClasses` in the `options` property, e.g.:

```json
{
  "type": "VerticalLayout",
  "elements": [
    {
      "type": "Control",
      "scope": "#/properties/name",
      "options": {
        "cssClasses": ["my-name-control-class"]
      }
    }
  ],
  "options": {
    "cssClasses": ["my-layout-class"]
  }
}
```

systopia-reference: 29920